### PR TITLE
fix alphanumeric bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@ function generateAlphaNumericCode(length, chars) {
   for (let i = length; i > 0; i--) {
     alphanumericCode += chars[Math.floor(Math.random() * chars.length)];
   }
-
   return alphanumericCode;
 }
 
 /*
- * @param {Object} self Model docuement reference
+ * @param {Object} self Model document reference
  * @param {String} code Alphanumeric code
  * @param {String} alphaNumId Field path set in model and passed in options
  * @param {Number} length Length for generating alphanumeric code

--- a/index.js
+++ b/index.js
@@ -7,48 +7,88 @@ function generateAlphaNumericCode(length, chars) {
   return alphanumericCode;
 }
 
-const alphanumericPlugin = function (schema, options) {
-  const optionsCpy = options || {};
+/*
+ * @param {Object} self Model docuement reference
+ * @param {String} code Alphanumeric code
+ * @param {String} alphaNumId Field path set in model and passed in options
+ * @param {Number} length Length for generating alphanumeric code
+ * @param {String} chars Set of characters from where alphanumeric code shall be generated
+ * @callback next
+ */
+function findNewCode(self, code, alphaNumId, length, chars, next) {
+  let query = {};
+  query[alphaNumId] = code;
+  query["_id"] = { $ne: self._id };
+  self.constructor.findOne(query, function (err, data) {
+    if (err) {
+      throw err;
+    }
+    if (!data) {
+      self[alphaNumId] = code;
+      next();
+    } else {
+      const newUniqueCode = generateAlphaNumericCode(length, chars);
+      findNewCode(self, newUniqueCode, alphaNumId, length, chars, next);
+    }
+  });
+}
 
-  let alphanumeric = optionsCpy.field ? optionsCpy.field : "alphanumeric";
+const alphanumericPlugin = function (schema, options) {
+  let optionsCpy = options || {};
+
   let unique = optionsCpy.unique ? true : false;
-  let length = optionsCpy.length ? parseInt(optionsCpy.length, 10) : 4;
+  let alphanumeric = optionsCpy.field ? optionsCpy.field : "alphanumeric";
+  let length = optionsCpy.length ? parseInt(optionsCpy.length, 10) : 4; //parse length to integer in case a string is provided in edge case
   let chars = optionsCpy.chars
     ? optionsCpy.chars
     : "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
+  // DOCUMENT MIDDLEWARE: runs before .save() and .create()
   schema.pre("save", function (next) {
+    //* If document is new then generate alphanumeric code
     if (this.isNew) {
       const uniqueCode = generateAlphaNumericCode(length, chars);
 
+      //* If alphanumeric is not unique then assign code to document without unique constraint check
       if (!unique) {
         this[alphanumeric] = uniqueCode;
         next();
       }
 
       let self = this;
+
+      findNewCode(self, uniqueCode, alphanumeric, length, chars, next);
+    } else {
+      let self = this;
       let query = {};
 
-      function findNewCode(code) {
-        query[alphanumeric] = code;
-        query["_id"] = { $ne: self._id };
+      function findCodeInDocument() {
+        query[alphanumeric] = { $exists: false };
+        query["_id"] = { $eq: self._id };
+        //* If document is not new then update document by _id where alphanumeric code does not exists
         self.constructor.findOne(query, function (err, data) {
           if (err) {
             throw err;
           }
-          if (!data) {
-            self[alphanumeric] = code;
-            next();
+          if (data) {
+            //* If no alphanumeric code exists in document then generate alphanumeric code
+            const uniqueCode = generateAlphaNumericCode(length, chars);
+            //* Non-unique constraint check for alphanumeric code
+            if (!unique) {
+              self[alphanumeric] = uniqueCode;
+              next();
+            } else {
+              //* Unique constraint check for alphanumeric code
+              findNewCode(self, uniqueCode, alphanumeric, length, chars, next);
+            }
           } else {
-            const newUniqueCode = generateAlphaNumericCode(length, chars);
-            findNewCode(newUniqueCode);
+            //* If alphanumeric code exists in document then exit middleware
+            next();
           }
         });
       }
 
-      findNewCode(uniqueCode);
-    } else {
-      next();
+      findCodeInDocument();
     }
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/mongoose-alphanumeric",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/mongoose-alphanumeric",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/mongoose-alphanumeric",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Alphanumeric code generator plugin for mongoose",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
Fix Alphanumeric code generation bug on model update operations. Alphanumeric code shall only generate when a new document is created. On subsequent changes to existing document, alphanumeric code shall not be generated and replace existing alphanumeric code.

### Changes
Added a check in schema [pre-save](https://mongoosejs.com/docs/middleware.html#pre) middleware that will only run the middleware when the document is added for the first time.

### Note to reviewer 
_How to test, caveats, etc._ 
Add new device using Postman or cloud, and update same device to check the consistency of alphanumeric code.

### Screenshots
Post request
![post](https://user-images.githubusercontent.com/107470646/194484462-fa5f8e08-d990-4143-89c8-a73179fdfd80.png)

Update Request
![put](https://user-images.githubusercontent.com/107470646/194484494-1c6b50aa-864a-4015-8ad6-0b034d216aae.png)


### Addresses issues
_Use github issue linking keywords (closes, fixes, resolves etc.). See [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Closes #3 

### Checklist
- [x] tested locally